### PR TITLE
Feature/user nickname

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,11 +27,7 @@
             android:theme="@style/SplashActivity"
             android:exported="true">
 
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
 
             <meta-data
                 android:name="android.app.lib_name"
@@ -67,6 +63,12 @@
             android:name=".presentation.register.RegisterActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
 
             <meta-data
                 android:name="android.app.lib_name"

--- a/app/src/main/java/com/starters/hsge/network/NicknameInterface.kt
+++ b/app/src/main/java/com/starters/hsge/network/NicknameInterface.kt
@@ -1,0 +1,14 @@
+package com.starters.hsge.network
+
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface NicknameInterface {
+
+    @POST("api/auth/duplicate-nickname")
+    fun postNickname(@Body nickname: NicknameRequest) : Call<NicknameResponse>
+}

--- a/app/src/main/java/com/starters/hsge/network/NicknameRequest.kt
+++ b/app/src/main/java/com/starters/hsge/network/NicknameRequest.kt
@@ -1,0 +1,8 @@
+package com.starters.hsge.network
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class NicknameRequest(
+    @SerialName("nickname") val nickname : String
+)

--- a/app/src/main/java/com/starters/hsge/network/NicknameResponse.kt
+++ b/app/src/main/java/com/starters/hsge/network/NicknameResponse.kt
@@ -1,0 +1,8 @@
+package com.starters.hsge.network
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class NicknameResponse(
+    @SerialName("data")val data: Boolean
+)

--- a/app/src/main/java/com/starters/hsge/presentation/register/fragment/UserImageFragment.kt
+++ b/app/src/main/java/com/starters/hsge/presentation/register/fragment/UserImageFragment.kt
@@ -20,6 +20,7 @@ class UserImageFragment : BaseFragment<FragmentUserImageBinding>(R.layout.fragme
         setNavigation()
         getSharedPreferences()
         if (prefs.contains("resId")){
+            binding.btnNext.isEnabled = true
             binding.ivUserImage.setImageResource(resId!!)
         } else {
             return

--- a/app/src/main/java/com/starters/hsge/presentation/register/fragment/UserNickNameFragment.kt
+++ b/app/src/main/java/com/starters/hsge/presentation/register/fragment/UserNickNameFragment.kt
@@ -1,22 +1,23 @@
 package com.starters.hsge.presentation.register.fragment
 
-import android.content.Context
-import android.content.Context.INPUT_METHOD_SERVICE
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.KeyEvent
-import android.view.KeyEvent.KEYCODE_ENTER
+import android.util.Log
 import android.view.View
-import android.view.inputmethod.InputMethodManager
-import androidx.core.content.ContextCompat.getSystemService
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
 import com.starters.hsge.R
 import com.starters.hsge.databinding.FragmentUserNickNameBinding
+import com.starters.hsge.network.*
 import com.starters.hsge.presentation.common.base.BaseFragment
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class UserNickNameFragment : BaseFragment<FragmentUserNickNameBinding>(R.layout.fragment_user_nick_name) {
+
+    private var nickNameFlag = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -24,7 +25,6 @@ class UserNickNameFragment : BaseFragment<FragmentUserNickNameBinding>(R.layout.
         setTextWatcher()
         setNavigation()
         initListener()
-        //setListenerToEditText()
     }
 
     private fun setTextWatcher() {
@@ -33,11 +33,29 @@ class UserNickNameFragment : BaseFragment<FragmentUserNickNameBinding>(R.layout.
             }
 
             override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                binding.btnNext.isEnabled = !binding.edtUserNickName.text.isNullOrBlank()
+                Log.d("입력한 값", "${binding.edtUserNickName.text.toString()}")
+                val value = NicknameRequest(binding.edtUserNickName.text.toString())
+                tryPostNickname(value)
             }
 
             override fun afterTextChanged(p0: Editable?) {
-
+                if (p0 != null) {
+                    when {
+                        p0.isNullOrBlank() -> {
+                            binding.tilUserNickName.error = "닉네임을 입력해주세요."
+                            nickNameFlag = false
+                        }
+                        !verifyNickname(p0.toString()) -> {
+                            binding.tilUserNickName.error = "닉네임 양식이 맞지 않습니다."
+                            nickNameFlag = false
+                        }
+                        else -> {
+                            binding.tilUserNickName.error = null
+                            nickNameFlag = true
+                        }
+                    }
+                    flagCheck()
+                }
             }
         })
     }
@@ -49,26 +67,55 @@ class UserNickNameFragment : BaseFragment<FragmentUserNickNameBinding>(R.layout.
         }
     }
 
-    // 엔터 시 포커스 제거 & 키보드 내리기
-    private fun setListenerToEditText() {
-        binding.edtUserNickName.setOnKeyListener { view, keyCode, event ->
-            // Enter Key Action
-            if ((event.action == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
-                view.clearFocus()
-                // 키패드 내리기
-                val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                imm.hideSoftInputFromWindow(binding.edtUserNickName.windowToken, 0)
-
-                return@setOnKeyListener true
-            }
-
-            false
-        }
-    }
-
     private fun setNavigation() {
         binding.toolBar.setNavigationOnClickListener {
             findNavController().navigateUp()
         }
     }
+
+    private fun tryPostNickname(value: NicknameRequest) {
+        val nicknameInterface = RetrofitClient.sRetrofit.create(NicknameInterface::class.java)
+        nicknameInterface.postNickname(nickname = value).enqueue(object :
+            Callback<NicknameResponse> {
+            override fun onResponse(
+                call: Call<NicknameResponse>,
+                response: Response<NicknameResponse>
+            ) {
+                if (response.isSuccessful) {
+                    val result = response.body() as NicknameResponse
+
+                    // true면 사용가능, false면 중복
+                    val availability = result.data
+                    Log.d("닉네임 설정 가능", "$availability / $value")
+
+                    if (availability==true) {
+                        // sp에 저장하기
+                        prefs.edit().putString("nickname", value.nickname).apply()
+
+                    } else {
+                        // 다시 입력하기
+                        binding.tilUserNickName.error = "이미 사용중인 닉네임입니다."
+                        nickNameFlag = false
+                        flagCheck()
+                    }
+
+                } else {
+                    Log.d(
+                        "userNickname", "getNickname - onResponse : Error code ${response.code()}"
+                    )
+                }
+            }
+
+            override fun onFailure(call: Call<NicknameResponse>, t: Throwable) {
+                Log.d("userNickname", t.message ?: "통신오류")
+            }
+
+        })
+    }
+
+    private fun flagCheck() {
+        binding.btnNext.isEnabled = nickNameFlag
+    }
+
+    private fun  verifyNickname(nickname: String): Boolean = nickname.matches(Regex("^[가-힣a-zA-Z0-9]{2,13}$"))
 }

--- a/app/src/main/res/layout/fragment_user_nick_name.xml
+++ b/app/src/main/res/layout/fragment_user_nick_name.xml
@@ -53,6 +53,9 @@
             android:layout_marginHorizontal="24dp"
             android:layout_marginTop="10dp"
             app:hintEnabled="false"
+            app:errorEnabled="true"
+            app:counterEnabled="true"
+            app:counterMaxLength="13"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_user_nickname_example">


### PR DESCRIPTION
## 💡 Issue
close #44 

## 🌱 Key changes
기존에 생각한 로직은 다음 버튼을 눌렀을 때 닉네임 중복확인을 진행하려고 했으나, 입력하는 순간마다 확인해서 오류 메시지로 띄워주는 것이 직관적이라고 생각하여 로직을 변경함

## ✅ To Reviewers
- 사용자 닉네임 EditText TextWatcher 처리
- 사용자 닉네임 EditText 정규식 처리
- 사용자 닉네임 중복확인 API 연동 (GET → POST)