### PR TITLE
Fix/logout_withdrawal

### DIFF
--- a/app/src/main/java/com/starters/hsge/presentation/main/mypage/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/starters/hsge/presentation/main/mypage/settings/SettingsFragment.kt
@@ -3,11 +3,13 @@ package com.starters.hsge.presentation.main.mypage.settings
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.navigation.fragment.findNavController
+import com.kakao.sdk.user.UserApiClient
 import com.starters.hsge.R
 import com.starters.hsge.databinding.FragmentSettingsBinding
 import com.starters.hsge.presentation.common.base.BaseFragment
@@ -38,9 +40,17 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>(R.layout.fragment
 
                 override fun onLogoutBtnClicked() {
                     // 확인 버튼 클릭했을 때 처리
-                    prefs.edit().clear().apply()
-                    moveToLoginActivity()
-                    Toast.makeText(context, "로그아웃 되었습니다.", Toast.LENGTH_SHORT).show()
+
+                    UserApiClient.instance.logout { error ->
+                        if (error != null) {
+                            Log.d("로그아웃", "로그아웃 실패 : ${error}")
+                            Toast.makeText(context, "다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                        }else {
+                            prefs.edit().clear().apply()
+                            moveToLoginActivity()
+                            Toast.makeText(context, "로그아웃 되었습니다.", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 }
             })
 

--- a/app/src/main/java/com/starters/hsge/presentation/main/mypage/settings/WithdrawalFragment.kt
+++ b/app/src/main/java/com/starters/hsge/presentation/main/mypage/settings/WithdrawalFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.navigation.fragment.findNavController
+import com.kakao.sdk.user.UserApiClient
 import com.starters.hsge.R
 import com.starters.hsge.databinding.FragmentWithdrawalBinding
 import com.starters.hsge.network.*
@@ -36,7 +37,14 @@ class WithdrawalFragment: BaseFragment<FragmentWithdrawalBinding>(R.layout.fragm
 
                 override fun onWithdrawalBtnClicked() {
                     // 탈퇴 버튼 클릭했을 때 처리
-                    tryDeleteUserInfo()
+                    UserApiClient.instance.unlink { error ->
+                        if (error != null) {
+                            Log.d("회원 탈퇴", "회원 탈퇴 실패 : ${error}")
+                            Toast.makeText(context, "다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                        }else {
+                            tryDeleteUserInfo()
+                        }
+                    }
                 }
             })
 


### PR DESCRIPTION
## 💡 Issue
close #76 

## 🌱 Key changes
로그아웃, 회원가입 로직 변경

## ✅ To Reviewers
- 카카오톡 SDK 내부에 있는 UserApiClient 사용해서 로그아웃 및 회원탈퇴 진행
-  탈퇴 후에 다시 가입할 때 카카오톡 동의 받게끔 수정
